### PR TITLE
fix: skip nonexistent system site-packages paths

### DIFF
--- a/src/picopip.py
+++ b/src/picopip.py
@@ -206,15 +206,6 @@ def _find_system_packages(venv_path: str) -> List[Path]:
                 include_system_site = line.split("=", 1)[1].strip()
                 if include_system_site == "true":
                     for sys_path in site.getsitepackages():
-                        # site.getsitepackages() includes sys.prefix's
-                        # site-packages dir unconditionally. On a CPython
-                        # built from source (default `configure` prefix is
-                        # /usr/local, common for manually-installed system
-                        # interpreters on RHEL 9 and similar distros), that
-                        # resolves to /usr/local/lib/pythonX.Y/site-packages,
-                        # which is only created once something is actually
-                        # pip-installed there outside a venv, so it's often
-                        # absent.
                         path = Path(sys_path)
                         if path.exists() and path.is_dir():
                             scan_paths.append(path)

--- a/src/picopip.py
+++ b/src/picopip.py
@@ -206,7 +206,9 @@ def _find_system_packages(venv_path: str) -> List[Path]:
                 include_system_site = line.split("=", 1)[1].strip()
                 if include_system_site == "true":
                     for sys_path in site.getsitepackages():
-                        scan_paths.append(Path(sys_path))
+                        path = Path(sys_path)
+                        if path.exists() and path.is_dir():
+                            scan_paths.append(path)
                 break
 
     return scan_paths

--- a/src/picopip.py
+++ b/src/picopip.py
@@ -206,6 +206,15 @@ def _find_system_packages(venv_path: str) -> List[Path]:
                 include_system_site = line.split("=", 1)[1].strip()
                 if include_system_site == "true":
                     for sys_path in site.getsitepackages():
+                        # site.getsitepackages() includes sys.prefix's
+                        # site-packages dir unconditionally. On a CPython
+                        # built from source (default `configure` prefix is
+                        # /usr/local, common for manually-installed system
+                        # interpreters on RHEL 9 and similar distros), that
+                        # resolves to /usr/local/lib/pythonX.Y/site-packages,
+                        # which is only created once something is actually
+                        # pip-installed there outside a venv, so it's often
+                        # absent.
                         path = Path(sys_path)
                         if path.exists() and path.is_dir():
                             scan_paths.append(path)

--- a/tests/test_packages_discovery.py
+++ b/tests/test_packages_discovery.py
@@ -214,10 +214,14 @@ def test_get_packages_from_env_skips_nonexistent_system_site_packages(
 ):
     """A nonexistent path returned by site.getsitepackages() must not crash.
 
-    On some platforms/interpreters site.getsitepackages() can list a path
-    (e.g. a prefix-based site-packages directory) that doesn't actually
-    exist on disk. It should be silently skipped, like nonexistent .pth
-    and PYTHONPATH entries already are, instead of raising.
+    site.getsitepackages() always includes sys.prefix's site-packages dir,
+    regardless of whether it exists. For a CPython built from source with
+    the default `configure` prefix (/usr/local) -- common for manually
+    installed system interpreters, e.g. on RHEL 9 -- that resolves to
+    /usr/local/lib/pythonX.Y/site-packages, which is only created once a
+    package is actually pip-installed there outside a venv, so it's
+    frequently absent. It should be silently skipped, like nonexistent
+    .pth and PYTHONPATH entries already are, instead of raising.
     """
     venv, site = fake_venv
     (venv / "pyvenv.cfg").write_text("include-system-site-packages = true\n")

--- a/tests/test_packages_discovery.py
+++ b/tests/test_packages_discovery.py
@@ -209,6 +209,27 @@ def test_get_packages_from_env_ignore_system_packages(tmp_path, monkeypatch):
     assert ("system-pkg", "0.1.0") not in pkgs
 
 
+def test_get_packages_from_env_skips_nonexistent_system_site_packages(
+    fake_venv, tmp_path, monkeypatch
+):
+    """A nonexistent path returned by site.getsitepackages() must not crash.
+
+    On some platforms/interpreters site.getsitepackages() can list a path
+    (e.g. a prefix-based site-packages directory) that doesn't actually
+    exist on disk. It should be silently skipped, like nonexistent .pth
+    and PYTHONPATH entries already are, instead of raising.
+    """
+    venv, site = fake_venv
+    (venv / "pyvenv.cfg").write_text("include-system-site-packages = true\n")
+    make_dist_info(site, "venv-pkg", "1.0.0")
+
+    missing_site = tmp_path / "does_not_exist" / "site-packages"
+    monkeypatch.setattr("picopip.site.getsitepackages", lambda: [str(missing_site)])
+
+    pkgs = get_packages_from_env(str(venv))
+    assert ("venv-pkg", "1.0.0") in pkgs
+
+
 def test_get_site_package_paths_includes_pythonpath(fake_venv, tmp_path, monkeypatch):
     """PYTHONPATH directories should be included in scan paths."""
     venv, _site = fake_venv


### PR DESCRIPTION
## Summary

`get_packages_from_env()` raises `NotADirectoryError` for any path in the scan list that doesn't exist on disk (added in #10). The `.pth`-file and `PYTHONPATH` discovery paths already guard with `.exists()` before adding a path to the scan list, but `_find_system_packages()` does not — so any venv with `include-system-site-packages = true` will crash whenever `site.getsitepackages()` returns a path that isn't actually present on that system/interpreter, which does happen in practice on some platforms.

This applies the same `exists()` + `is_dir()` guard already used by the other two path sources, so a missing system site-packages directory is silently skipped instead of raising.

## Test plan

- Added `test_get_packages_from_env_skips_nonexistent_system_site_packages`, which mocks `site.getsitepackages()` to return a nonexistent path and asserts `get_packages_from_env` still succeeds and finds the venv's own packages.
- Verified the new test fails with `NotADirectoryError` against the pre-fix code and passes with the fix.
- Full suite: `133 passed`.
- `ruff check` and `ruff format --check` pass.